### PR TITLE
Fix Typo in Command name: RefreshAccessTokenSpotifyCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ protected function schedule(Schedule $schedule)
 {
     // ...
             $schedule->command(\Ashbakernz\SpotifyTile\FetchDataFromSpotifyCommand::class)->everyMinute();
-            $schedule->command(\Ashbakernz\SpotifyTile\RefeshAccessTokenSpotifyCommand::class)->everyFifteenMinutes();
+            $schedule->command(\Ashbakernz\SpotifyTile\RefreshAccessTokenSpotifyCommand::class)->everyFifteenMinutes();
 }
 ```
 

--- a/src/SpotifyTileServiceProvider.php
+++ b/src/SpotifyTileServiceProvider.php
@@ -12,7 +12,7 @@ class SpotifyTileServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 FetchDataFromSpotifyCommand::class,
-                RefeshAccessTokenSpotifyCommand::class,
+                RefreshAccessTokenSpotifyCommand::class,
             ]);
         }
 


### PR DESCRIPTION
The Command Class to refresh the access token is named RefreshAccessTokenSpotifyCommand
However, in the Readme, and in the serviceprovider, it was named  RefeshAccessTokenSpotifyCommand, which is both confusing, and causes an error.

This PR fixes both.

